### PR TITLE
Assume us-ascii charset on input if not specified, write out UTF-8

### DIFF
--- a/lib/Email/Footer/RW/Email/MIME.pm
+++ b/lib/Email/Footer/RW/Email/MIME.pm
@@ -54,6 +54,8 @@ sub walk_parts {
       }
 
       # No charset? Default to us-ascii (perhaps Email::MIME should do this?)
+      # This is for input only. We will always write out UTF-8 as our template
+      # may contain it
       my $ct = Email::MIME::parse_content_type($part->content_type);
       unless ($ct->{attributes}{charset}) {
         $part->charset_set('us-ascii');
@@ -61,6 +63,10 @@ sub walk_parts {
 
       my $body = $part->body_str;
       $text_sub->(\$body);
+
+      # change to UTF-8
+      $part->charset_set('UTF-8');
+
       $part->body_str_set($body);
     } elsif ($part->content_type =~ m[text/html]i) {
       return unless $html_sub;
@@ -72,6 +78,8 @@ sub walk_parts {
         unless $cte =~ /\A (?: quoted-printable | base64 ) \z/ix;
 
       # No charset? Default to us-ascii (perhaps Email::MIME should do this?)
+      # This is for input only. We will always write out UTF-8 as our template
+      # may contain it
       my $ct = Email::MIME::parse_content_type($part->content_type);
       unless ($ct->{attributes}{charset}) {
         $part->charset_set('us-ascii');
@@ -79,6 +87,10 @@ sub walk_parts {
 
       my $body = $part->body_str;
       $html_sub->(\$body);
+
+      # change to UTF-8
+      $part->charset_set('UTF-8');
+
       $part->body_str_set($body);
     }
   });

--- a/t/html-footers.t
+++ b/t/html-footers.t
@@ -13,9 +13,9 @@ use utf8;
 
 subtest "basic text footer add/removal" => sub {
   my $tfoot = <<'EOF';
-{ $group_name }<br />
-{ $group_url }<br />
-Powered by Perl<br />
+{ $group_name } …<br />
+{ $group_url } …<br />
+Powered by Perl …<br />
 EOF
 
   my $footer = Email::Footer->new({
@@ -77,9 +77,9 @@ EOF
 <body>
   <a href="https://example.net">Wow what an Email</a>
 <div id="heavy-footer" style="width: auto; margin: 0">
-Better Faster Stronger<br />
-https://example.net/groups/bfs<br />
-Powered by Perl<br />
+Better Faster Stronger …<br />
+https://example.net/groups/bfs …<br />
+Powered by Perl …<br />
 </div>
 </body>
 </html>
@@ -118,9 +118,9 @@ EOF
 
 subtest "quoted html footer removal" => sub {
   my $tfoot = <<'EOF';
-{ $group_name }<br />
-{ $group_url }<br />
-Powered by Perl<br />
+{ $group_name } …<br />
+{ $group_url } …<br />
+Powered by Perl …<br />
 EOF
 
   my $footer = Email::Footer->new({
@@ -147,9 +147,9 @@ EOF
         },
         body_str => <<'EOF',
 <div dir="ltr">Oh <b>boy</b><br><div><div class="gmail_extra"><br><div class="gmail_quote">On Fri, Oct 28, 2016 at 1:02 PM,  <span dir="ltr">&lt;<a href="mailto:someone@example.net" target="_blank">someone@example.net</a>&gt;</span> wrote:<br><blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex"><div><a href="https://example.net" target="_blank">Wow what an Email</a><div id="m_5048774373898288484heavy-footer" style="width:auto;margin:0">
-Better Faster Stronger<br>
-<a href="https://example.net/groups/bfs" target="_blank">https://example.net/groups/bfs</a><br>
-Powered by Perl<br>
+Better Faster Stronger …<br>
+<a href="https://example.net/groups/bfs" target="_blank">https://example.net/groups/bfs …</a><br>
+Powered by Perl …<br>
 </div>
 </div>
 </blockquote></div><br></div></div></div>
@@ -160,12 +160,12 @@ EOF
 
   # Verify initial state
   for my $str (
-    "Better Faster Stronger",
-    "https://example.net/groups/bfs",
-    "Powered by Perl",
+    "Better Faster Stronger …",
+    "https://example.net/groups/bfs …",
+    "Powered by Perl …",
   ) {
     like(
-      $email->as_string,
+      $email->body_str,
       qr/\Q$str\E/,
       "footer exits"
     );
@@ -174,14 +174,14 @@ EOF
   # Now strip the footers
   $footer->strip_footers($email);
 
-  # Verify initial state
+  # Verify these are now gone
   for my $str (
-    "Better Faster Stronger",
-    "https://example.net/groups/bfs",
-    "Powered by Perl",
+    "Better Faster Stronger …",
+    "https://example.net/groups/bfs …",
+    "Powered by Perl …",
   ) {
     unlike(
-      $email->as_string,
+      $email->body_str,
       qr/\Q$str\E/,
       "footer cleared from quoted response"
     );
@@ -194,9 +194,9 @@ subtest "Make sure match works based on style" => sub {
   # id to make sure style matching works
 
   my $tfoot = <<'EOF';
-{ $group_name }<br />
-{ $group_url }<br />
-Powered by Perl<br />
+{ $group_name } …<br />
+{ $group_url } …<br />
+Powered by Perl …<br />
 EOF
 
   my $footer = Email::Footer->new({
@@ -223,9 +223,9 @@ EOF
         },
         body_str => <<'EOF',
 <div dir="ltr">Oh <b>boy</b><br><div><div class="gmail_extra"><br><div class="gmail_quote">On Fri, Oct 28, 2016 at 1:02 PM,  <span dir="ltr">&lt;<a href="mailto:someone@example.net" target="_blank">someone@example.net</a>&gt;</span> wrote:<br><blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex"><div><a href="https://example.net" target="_blank">Wow what an Email</a><div id="m_5048774373898288484broken-footer" style="width:auto;margin:0">
-Better Faster Stronger<br>
-<a href="https://example.net/groups/bfs" target="_blank">https://example.net/groups/bfs</a><br>
-Powered by Perl<br>
+Better Faster Stronger …<br>
+<a href="https://example.net/groups/bfs" target="_blank">https://example.net/groups/bfs …</a><br>
+Powered by Perl …<br>
 </div>
 </div>
 </blockquote></div><br></div></div></div>
@@ -236,12 +236,12 @@ EOF
 
   # Verify initial state
   for my $str (
-    "Better Faster Stronger",
-    "https://example.net/groups/bfs",
-    "Powered by Perl",
+    "Better Faster Stronger …",
+    "https://example.net/groups/bfs …",
+    "Powered by Perl …",
   ) {
     like(
-      $email->as_string,
+      $email->body_str,
       qr/\Q$str\E/,
       "footer exits"
     );
@@ -250,14 +250,14 @@ EOF
   # Now strip the footers
   $footer->strip_footers($email);
 
-  # Verify initial state
+  # Verify tese are now gone
   for my $str (
-    "Better Faster Stronger",
-    "https://example.net/groups/bfs",
-    "Powered by Perl",
+    "Better Faster Stronger …",
+    "https://example.net/groups/bfs …",
+    "Powered by Perl …",
   ) {
     unlike(
-      $email->as_string,
+      $email->body_str,
       qr/\Q$str\E/,
       "footer cleared from quoted response"
     );
@@ -268,9 +268,9 @@ subtest "ensure lines over 778 bytes aren't possible" => sub {
   my $long_line = "x" x 1024;
 
   my $tfoot = <<"EOF";
-$long_line { \$group_name }<br />
-$long_line { \$group_url }<br />
-$long_line Powered by Perl<br />
+$long_line { \$group_name } …<br />
+$long_line { \$group_url } …<br />
+$long_line Powered by Perl …<br />
 EOF
 
   my $footer = Email::Footer->new({
@@ -349,9 +349,9 @@ EOF
 <body>
   <a href="https://example.net">Wow what an Email</a>
 <div id="heavy-footer" style="width: auto; margin: 0">
-$long_line Better Faster Stronger<br />
-$long_line https://example.net/groups/bfs<br />
-$long_line Powered by Perl<br />
+$long_line Better Faster Stronger …<br />
+$long_line https://example.net/groups/bfs …<br />
+$long_line Powered by Perl …<br />
 </div>
 </body>
 </html>
@@ -390,9 +390,9 @@ EOF
 
 subtest "no charset" => sub {
   my $tfoot = <<'EOF';
-{ $group_name }<br />
-{ $group_url }<br />
-Powered by Perl<br />
+{ $group_name } …<br />
+{ $group_url } …<br />
+Powered by Perl …<br />
 EOF
 
   my $footer = Email::Footer->new({
@@ -453,9 +453,9 @@ EOF
 <body>
   <a href="https://example.net">Wow what an Email</a>
 <div id="heavy-footer" style="width: auto; margin: 0">
-Better Faster Stronger<br />
-https://example.net/groups/bfs<br />
-Powered by Perl<br />
+Better Faster Stronger …<br />
+https://example.net/groups/bfs …<br />
+Powered by Perl …<br />
 </div>
 </body>
 </html>

--- a/t/text-footers.t
+++ b/t/text-footers.t
@@ -13,15 +13,15 @@ use utf8;
 
 subtest "basic text footer add/removal" => sub {
   my $tfoot = <<'EOF';
-{ $group_name }
-{ $group_url }
+{ $group_name } …
+{ $group_url } …
 EOF
 
   my $footer = Email::Footer->new({
     template => {
       text => {
         start_delim => ('-' x 42),
-        end_delim   => "Powered by Perl",
+        end_delim   => "Powered by Perl …",
         template    => $tfoot,
       },
     },
@@ -60,9 +60,9 @@ EOF
 This is part one. It is a lonely part…
 
 ------------------------------------------
-Better Faster Stronger
-https://example.net/groups/bfs
-Powered by Perl
+Better Faster Stronger …
+https://example.net/groups/bfs …
+Powered by Perl …
 EOF
     "Footer looks right"
   );
@@ -80,27 +80,28 @@ EOF
 
 subtest "quoted footer removal" => sub {
   my $tfoot = <<'EOF';
-{ $group_name }
-{ $group_url }
+{ $group_name } …
+{ $group_url } …
 EOF
 
   my $footer = Email::Footer->new({
     template => {
       text => {
         start_delim => ('-' x 42),
-        end_delim   => "Powered by Perl",
+        end_delim   => "Powered by Perl …",
         template    => $tfoot,
       },
     },
   });
 
+  # On an originally us-ascii email
   my $email = Email::MIME->create(
     header_str => [
       From => 'my@address',
       To   => 'your@address',
     ],
     parts => [
-      "This is part one. It is a lonely part.\n",
+      "This is part one. It is a lonely part\n",
     ],
   );
 
@@ -117,12 +118,12 @@ EOF
   eq_or_diff(
     $body,
     <<'EOF',
-This is part one. It is a lonely part.
+This is part one. It is a lonely part
 
 ------------------------------------------
-Better Faster Stronger
-https://example.net/groups/bfs
-Powered by Perl
+Better Faster Stronger …
+https://example.net/groups/bfs …
+Powered by Perl …
 EOF
     "Footer looks right"
   );
@@ -138,7 +139,7 @@ EOF
       # Quote the message
       $body =~ s/^/> /mg;
 
-      $part->body_str_set( "Top posted response OH NO!\n\n$body" );
+      $part->body_str_set( "Top posted response… OH NO!\n\n$body" );
     }
   });
 
@@ -149,14 +150,14 @@ EOF
   eq_or_diff(
     $body,
     <<EOF,
-Top posted response OH NO!
+Top posted response… OH NO!
 
-> This is part one. It is a lonely part.
+> This is part one. It is a lonely part
 > 
 > ------------------------------------------
-> Better Faster Stronger
-> https://example.net/groups/bfs
-> Powered by Perl
+> Better Faster Stronger …
+> https://example.net/groups/bfs …
+> Powered by Perl …
 EOF
   'modified message looks right'
   );
@@ -169,9 +170,9 @@ EOF
   eq_or_diff(
     $body,
     <<EOF,
-Top posted response OH NO!
+Top posted response… OH NO!
 
-> This is part one. It is a lonely part.
+> This is part one. It is a lonely part
 EOF
   'stripped footers from quoted text'
   );
@@ -181,15 +182,15 @@ subtest "ensure lines over 778 bytes aren't possible" => sub {
   my $long_line = "x" x 1024;
 
   my $tfoot = <<"EOF";
-$long_line { \$group_name }
-$long_line { \$group_url }
+$long_line { \$group_name } …
+$long_line { \$group_url } …
 EOF
 
   my $footer = Email::Footer->new({
     template => {
       text => {
         start_delim => ('-' x 42),
-        end_delim   => "Powered by Perl",
+        end_delim   => "Powered by Perl …",
         template    => $tfoot,
       },
     },
@@ -207,7 +208,7 @@ EOF
           encoding     => "8bit", # This will keep our original line lengths
           charset      => "UTF-8",
         },
-        body_str => "This is part one. It is a lonely part.\n",
+        body_str => "This is part one. It is a lonely part…\n",
       ),
     ],
   );
@@ -233,12 +234,12 @@ EOF
   eq_or_diff(
     $body,
     <<"EOF",
-This is part one. It is a lonely part.
+This is part one. It is a lonely part…
 
 ------------------------------------------
-$long_line Better Faster Stronger
-$long_line https://example.net/groups/bfs
-Powered by Perl
+$long_line Better Faster Stronger …
+$long_line https://example.net/groups/bfs …
+Powered by Perl …
 EOF
     "Footer looks right"
   );
@@ -249,7 +250,9 @@ EOF
   my $email_str = $email->as_string;
   $orig =~ s/\r\n/\n/g;
   $email_str =~ s/\r\n/\n/g;
+
   $orig =~ s/8bit/quoted-printable/;
+  $orig =~ s/\xe2\x80\xa6/=E2=80=A6/;# 8bit -> quoted-printable
 
   eq_or_diff($email_str, $orig, 'string returned to original form');
 };


### PR DESCRIPTION
Our templates may contain UTF-8 characters, so to be safe just
write out a UTF-8 charset always.