### PR TITLE
Footers in subparts

### DIFF
--- a/lib/Email/Footer/RW/Email/MIME.pm
+++ b/lib/Email/Footer/RW/Email/MIME.pm
@@ -91,6 +91,11 @@ sub walk_parts {
     }
 
     if ($part->content_type =~ m[text/plain]i) {
+      my $disp = $part->header('Content-Disposition');
+
+      # Do *not* mess with non-inline attachments
+      next if $disp && $disp =~ /attachment/i;
+
       next if $dont_strip_text || ! $text_sub;
 
       push @{ $parts{text} }, $part;

--- a/share/t/corpus/alternative/attached-email-1/input.msg
+++ b/share/t/corpus/alternative/attached-email-1/input.msg
@@ -1,0 +1,50 @@
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+MIME-Version: 1.0
+Subject: A test message
+Content-Transfer-Encoding: 7bit
+Content-Transfer-Encoding: 7bit
+Content-Type: multipart/mixed; boundary="_----------=_149118122329790551"
+
+
+--_----------=_149118122329790551
+Content-Transfer-Encoding: 7bit
+Content-Type: multipart/alternative; boundary="_----------=_149118122329790550"
+Content-ID: <14911812280.cD87a05.98950@tb-core1>
+
+This is a multi-part message in MIME format.
+
+--_----------=_149118122329790550
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset="utf-8"
+
+This is a test message=
+
+
+--_----------=_149118122329790550
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset="utf-8"
+
+<html><head><title>hi</title></head><body><div>This is a test message.</bod=
+y></html>
+
+--_----------=_149118122329790550--
+
+
+--_----------=_149118122329790551
+Content-Disposition: attachment; filename="amessage.eml"
+Content-Transfer-Encoding: 8bit
+Content-Type: message/rfc822; name="amessage.eml"
+
+Date: Sat,  1 Apr 2017 06:32:57 -0400 (EDT)
+From: someone@example.net
+Subject: A subject
+To: someoneelse@example.net
+MIME-Version: 1.0
+
+This is a message
+
+--D14916E265.1491042777/tb-core1.topicbox.com
+
+--_----------=_149118122329790551--

--- a/share/t/corpus/alternative/attached-email-1/output.msg
+++ b/share/t/corpus/alternative/attached-email-1/output.msg
@@ -1,0 +1,59 @@
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+MIME-Version: 1.0
+Subject: A test message
+Content-Transfer-Encoding: 7bit
+Content-Transfer-Encoding: 7bit
+Content-Type: multipart/mixed; boundary="_----------=_149118122329790551"
+
+
+--_----------=_149118122329790551
+Content-Transfer-Encoding: 7bit
+Content-Type: multipart/alternative; boundary="_----------=_149118122329790550"
+Content-ID: <14911812280.cD87a05.98950@tb-core1>
+
+This is a multi-part message in MIME format.
+
+--_----------=_149118122329790550
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset="utf-8"
+
+This is a test message
+
+------------------------------------------
+Better Faster Stronger =E2=80=A6
+https://example.net/groups/bfs =E2=80=A6
+Powered by Perl =E2=80=A6
+
+--_----------=_149118122329790550
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset="utf-8"
+
+<html><html><html><head><title>hi</title></head><body><div>This is a test m=
+essage.</div><div id=3D"heavy-footer" style=3D"width: auto; margin: 0">
+Better Faster Stronger =E2=80=A6<br />
+https://example.net/groups/bfs =E2=80=A6<br />
+Powered by Perl =E2=80=A6<br />
+</div>
+</body></html></html></html>=
+
+--_----------=_149118122329790550--
+
+
+--_----------=_149118122329790551
+Content-Disposition: attachment; filename="amessage.eml"
+Content-Transfer-Encoding: 8bit
+Content-Type: message/rfc822; name="amessage.eml"
+
+Date: Sat,  1 Apr 2017 06:32:57 -0400 (EDT)
+From: someone@example.net
+Subject: A subject
+To: someoneelse@example.net
+MIME-Version: 1.0
+
+This is a message
+
+--D14916E265.1491042777/tb-core1.topicbox.com
+
+--_----------=_149118122329790551--

--- a/share/t/corpus/alternative/attached-email-1/shortdesc.txt
+++ b/share/t/corpus/alternative/attached-email-1/shortdesc.txt
@@ -1,0 +1,1 @@
+We can add footers to a complex multipart message

--- a/share/t/corpus/alternative/attached-email-1/template.json
+++ b/share/t/corpus/alternative/attached-email-1/template.json
@@ -1,0 +1,19 @@
+{
+   "template" : {
+      "text" : {
+         "end_delim" : "Powered by Perl …",
+         "start_delim" : "------------------------------------------",
+         "template" : "{ $group_name } …\n{ $group_url } …\n"
+      },
+      "html" : {
+         "start_delim" : "<div id=\"heavy-footer\" style=\"width: auto; margin: 0\">",
+         "end_delim" : "</div>",
+         "template" : "{ $group_name } …<br />\n{ $group_url } …<br />\nPowered by Perl …<br />\n"
+      }
+   },
+   "values" : {
+      "group_name" : "Better Faster Stronger",
+      "group_url" : "https://example.net/groups/bfs"
+   }
+}
+

--- a/share/t/corpus/text/basic-attachment-1/input.msg
+++ b/share/t/corpus/text/basic-attachment-1/input.msg
@@ -1,0 +1,27 @@
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+MIME-Version: 1.0
+Subject: A test message
+Content-Type: multipart/mixed; boundary="14928047760.36Dfd.14226"
+Content-Transfer-Encoding: 7bit
+
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+Hello there
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"; name="attach.txt"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: attachment
+
+Attachment !=
+
+--14928047760.36Dfd.14226--

--- a/share/t/corpus/text/basic-attachment-1/output.msg
+++ b/share/t/corpus/text/basic-attachment-1/output.msg
@@ -1,0 +1,32 @@
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+MIME-Version: 1.0
+Subject: A test message
+Content-Type: multipart/mixed; boundary="14928047760.36Dfd.14226"
+Content-Transfer-Encoding: 7bit
+
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+Hello there
+
+------------------------------------------
+Better Faster Stronger =E2=80=A6
+https://example.net/groups/bfs =E2=80=A6
+Powered by Perl =E2=80=A6
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"; name="attach.txt"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: attachment
+
+Attachment !=
+
+--14928047760.36Dfd.14226--

--- a/share/t/corpus/text/basic-attachment-1/shortdesc.txt
+++ b/share/t/corpus/text/basic-attachment-1/shortdesc.txt
@@ -1,0 +1,1 @@
+We do not add footers to non-inline attachments!

--- a/share/t/corpus/text/basic-attachment-1/template.json
+++ b/share/t/corpus/text/basic-attachment-1/template.json
@@ -1,0 +1,14 @@
+{
+   "template" : {
+      "text" : {
+         "end_delim" : "Powered by Perl …",
+         "start_delim" : "------------------------------------------",
+         "template" : "{ $group_name } …\n{ $group_url } …\n"
+      }
+   },
+   "values" : {
+      "group_name" : "Better Faster Stronger",
+      "group_url" : "https://example.net/groups/bfs"
+   }
+}
+

--- a/share/t/corpus/text/basic-attachment-response-1/input.msg
+++ b/share/t/corpus/text/basic-attachment-response-1/input.msg
@@ -1,0 +1,41 @@
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+MIME-Version: 1.0
+Subject: A test message
+Content-Type: multipart/mixed; boundary="14928047760.36Dfd.14226"
+Content-Transfer-Encoding: 7bit
+
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+> Hello there
+
+Hi!
+
+>
+>
+> ------------------------------------------
+> Better Faster Stronger =E2=80=A6
+> https://example.net/groups/bfs =E2=80=A6
+> Powered by Perl =E2=80=A6
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"; name="attach.txt"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: attachment
+
+Attachment contains footer!
+
+> ------------------------------------------
+> Better Faster Stronger =E2=80=A6
+> https://example.net/groups/bfs =E2=80=A6
+> Powered by Perl =E2=80=A6
+
+--14928047760.36Dfd.14226--

--- a/share/t/corpus/text/basic-attachment-response-1/output.msg
+++ b/share/t/corpus/text/basic-attachment-response-1/output.msg
@@ -1,0 +1,41 @@
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+MIME-Version: 1.0
+Subject: A test message
+Content-Type: multipart/mixed; boundary="14928047760.36Dfd.14226"
+Content-Transfer-Encoding: 7bit
+
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+> Hello there
+
+Hi!
+
+>=20
+
+------------------------------------------
+Better Faster Stronger =E2=80=A6
+https://example.net/groups/bfs =E2=80=A6
+Powered by Perl =E2=80=A6
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"; name="attach.txt"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: attachment
+
+Attachment contains footer!
+
+> ------------------------------------------
+> Better Faster Stronger =E2=80=A6
+> https://example.net/groups/bfs =E2=80=A6
+> Powered by Perl =E2=80=A6
+
+--14928047760.36Dfd.14226--

--- a/share/t/corpus/text/basic-attachment-response-1/shortdesc.txt
+++ b/share/t/corpus/text/basic-attachment-response-1/shortdesc.txt
@@ -1,0 +1,1 @@
+We do not strip footers from non-inline attachments!

--- a/share/t/corpus/text/basic-attachment-response-1/template.json
+++ b/share/t/corpus/text/basic-attachment-response-1/template.json
@@ -1,0 +1,14 @@
+{
+   "template" : {
+      "text" : {
+         "end_delim" : "Powered by Perl …",
+         "start_delim" : "------------------------------------------",
+         "template" : "{ $group_name } …\n{ $group_url } …\n"
+      }
+   },
+   "values" : {
+      "group_name" : "Better Faster Stronger",
+      "group_url" : "https://example.net/groups/bfs"
+   }
+}
+

--- a/share/t/corpus/text/basic-inline-attachment-1/input.msg
+++ b/share/t/corpus/text/basic-inline-attachment-1/input.msg
@@ -1,0 +1,26 @@
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+MIME-Version: 1.0
+Subject: A test message
+Content-Type: multipart/mixed; boundary="14928047760.36Dfd.14226"
+Content-Transfer-Encoding: 7bit
+
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+Hello there
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"; name="attach.txt"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+Inline attachment !=
+
+--14928047760.36Dfd.14226--

--- a/share/t/corpus/text/basic-inline-attachment-1/output.msg
+++ b/share/t/corpus/text/basic-inline-attachment-1/output.msg
@@ -1,0 +1,31 @@
+From: Example Sender <sender@example.net>
+To: Example Receiver <receiver@example.net>
+Date: Fri, 04 Nov 2016 12:03:28 -0400
+MIME-Version: 1.0
+Subject: A test message
+Content-Type: multipart/mixed; boundary="14928047760.36Dfd.14226"
+Content-Transfer-Encoding: 7bit
+
+
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+Hello there
+--14928047760.36Dfd.14226
+Date: Fri, 21 Apr 2017 15:59:36 -0400
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"; name="attach.txt"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+Inline attachment !=
+
+------------------------------------------
+Better Faster Stronger =E2=80=A6
+https://example.net/groups/bfs =E2=80=A6
+Powered by Perl =E2=80=A6
+
+--14928047760.36Dfd.14226--

--- a/share/t/corpus/text/basic-inline-attachment-1/shortdesc.txt
+++ b/share/t/corpus/text/basic-inline-attachment-1/shortdesc.txt
@@ -1,0 +1,1 @@
+We add footers to inline plaintext attachments

--- a/share/t/corpus/text/basic-inline-attachment-1/template.json
+++ b/share/t/corpus/text/basic-inline-attachment-1/template.json
@@ -1,0 +1,14 @@
+{
+   "template" : {
+      "text" : {
+         "end_delim" : "Powered by Perl …",
+         "start_delim" : "------------------------------------------",
+         "template" : "{ $group_name } …\n{ $group_url } …\n"
+      }
+   },
+   "values" : {
+      "group_name" : "Better Faster Stronger",
+      "group_url" : "https://example.net/groups/bfs"
+   }
+}
+

--- a/t/all.t
+++ b/t/all.t
@@ -1,0 +1,13 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Email::Footer::Test;
+
+Email::Footer::Test->new({
+  dir => 'share',
+})->run_all_tests;
+
+done_testing;


### PR DESCRIPTION
This fixes two bugs:

  - Make sure we don't add/strip footers from non-inline attachments
  - Make sure when we add a footer to the final text part we find that it *ACTUALLY* bubbles up to the final rewritten message

The latter was not happening because Email::MIME caching...